### PR TITLE
Create add-team-label-to-pr workflow

### DIFF
--- a/workflow-templates/add-team-label-to-pr
+++ b/workflow-templates/add-team-label-to-pr
@@ -1,0 +1,15 @@
+name: Assign PR team labels
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  team-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: equitybee/team-label-action@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          organization-name: YFTRLabs


### PR DESCRIPTION
https://github.com/marketplace/actions/team-label-action

We can use this action to automatically assign a team label (based on github teams) to a PR. This will then allows us to subscribe to specifically labeled PRs in Slack.